### PR TITLE
Fix: Uncaught TypeError when not logged in to Wordpress

### DIFF
--- a/src/lib/brain.js
+++ b/src/lib/brain.js
@@ -44,12 +44,15 @@ var wpAdminHide = {
   removeBar: function(tabId) {
     chrome.tabs.executeScript(
       tabId, {
-        code: [
-          "document.getElementById('wpadminbar').style.display = 'none';",
-          "document.getElementsByTagName('html')[0].style.setProperty('margin-top', '0px', 'important');",
-          "document.getElementsByTagName('html')[0].style.setProperty('padding-top', '0px', 'important');",
-          "document.getElementsByTagName('body')[0].classList.remove('admin-bar');"
-        ].join(''),
+        code: `
+          var wpadminbar = document.getElementById('wpadminbar');
+          if (wpadminbar) {
+            wpadminbar.style.display = 'none';
+            document.documentElement.style.setProperty('margin-top', '0px', 'important');
+            document.documentElement.style.setProperty('padding-top', '0px', 'important');
+            document.body.classList.remove('admin-bar');
+          }
+        `,
         runAt: "document_idle",
         allFrames: true
       },
@@ -61,11 +64,14 @@ var wpAdminHide = {
   restoreBar: function(tabId) {
     chrome.tabs.executeScript(
       tabId, {
-        code: [
-          "document.getElementById('wpadminbar').removeAttribute('style');",
-          "document.getElementsByTagName('html')[0].removeAttribute('style');",
-          "document.getElementsByTagName('body')[0].classList.add('admin-bar');"
-        ].join(''),
+        code: `
+          var wpadminbar = document.getElementById('wpadminbar');
+          if (wpadminbar) {
+            wpadminbar.removeAttribute('style');
+            document.documentElement.removeAttribute('style');
+            document.body.classList.add('admin-bar');
+          }
+        `,
         runAt: "document_idle",
         allFrames: true
       },


### PR DESCRIPTION
Fixes #3, also I've changed the code block from `[].join('')` to backquotes/backticks since that allows us to write multiple lines of Javascript code and it will be treated as a single string for the `code` property. I also changed `document.getElementsByTagName('body')[0]` to `document.body` and `document.getElementsByTagName('html')[0]` to `document. documentElement ` since those are the native Javascript properties for those `body` and `html` tags.