### PR TITLE
Migrate to Manifest V3 and Release 2.0.0

### DIFF
--- a/src/lib/brain.js
+++ b/src/lib/brain.js
@@ -8,7 +8,7 @@ const wpAdminHide = {
     let obj = {};
     obj[domain] = true;
     chrome.storage.sync.set(obj, function(){
-        // console.log("Domain added: " + domain);
+        // console.log(domain + "added to storage, admin bar removed.");
     });
   },
 
@@ -17,7 +17,7 @@ const wpAdminHide = {
    */
   remD: function(domain) {
     chrome.storage.sync.remove(domain, function(){
-        // console.log("Domain removed: " + domain);
+        // console.log(domain + "removed to storage, admin bar restored.");
     });
   },
 
@@ -28,7 +28,7 @@ const wpAdminHide = {
   chkD: function(tabId, yes, no) {
     chrome.tabs.get(tabId, function(tab) {
       if (tab.url.startsWith("chrome")) {
-        console.error("can't run on chrome pages, sorry :(");
+        console.error("Can't run on Chrome pages, sorry :(");
         return;
       }
       let domain = tab.url.split("/")[2];

--- a/src/lib/brain.js
+++ b/src/lib/brain.js
@@ -1,116 +1,105 @@
-var wpAdminHide = {
+// Wordpress Admin Bar Control - Manifest V3 version
 
-  /*
+const wpAdminHide = {
+  /**
    * Adds a domain name to Chrome storage
    */
-  addD: function(d) {
-    var save = {};
-    save[d] = true;
-    chrome.storage.sync.set(save, function(result) {
-      console.log(d, "added to storage, admin bar removed.");
+  addD: function(domain) {
+    let obj = {};
+    obj[domain] = true;
+    chrome.storage.sync.set(obj, function(){
+        // console.log("Domain added: " + domain);
     });
   },
 
-  /*
+  /**
    * Removes a domain from Chrome storage
    */
-  remD: function(d) {
-    chrome.storage.sync.remove(d, function() {
-      console.log(d, "removed from storage, admin bar restored.");
+  remD: function(domain) {
+    chrome.storage.sync.remove(domain, function(){
+        // console.log("Domain removed: " + domain);
     });
   },
 
-  /*
-   * Checks for the existence of a Chrome storage item that matches the domain passed as the first
-   * argument. Second and third arguments are what to do if there is or isn't a match, respectively.
+  /**
+   * Checks for the existence of a Chrome storage item that matches the domain
+   * Second and third arguments are callbacks for match/no match
    */
-  chkD: function(tabId, pass, fail) {
+  chkD: function(tabId, yes, no) {
     chrome.tabs.get(tabId, function(tab) {
-      if(tab.url.indexOf('chrome') == 0){
-        console.error('can\'t run on chrome pages, sorry :(');
-      }else{
-        d = tab.url.split("/")[2];
-        chrome.storage.sync.get(d, function(result){
-          if (result[d]) {
-            pass(d);
-          } else {
-            fail(d);
-          }
-        });
+      if (tab.url.startsWith("chrome")) {
+        console.error("can't run on chrome pages, sorry :(");
+        return;
       }
+      let domain = tab.url.split("/")[2];
+      chrome.storage.sync.get(domain, function(result) {
+        result[domain] ? yes(domain) : no(domain);
+      });
     });
   },
 
-  removeBar: function(tabId) {
-    chrome.tabs.executeScript(
-      tabId, {
-        code: [
-          "document.getElementById('wpadminbar').style.display = 'none';",
-          "document.getElementsByTagName('html')[0].style.setProperty('margin-top', '0px', 'important');",
-          "document.getElementsByTagName('html')[0].style.setProperty('padding-top', '0px', 'important');",
-          "document.getElementsByTagName('body')[0].classList.remove('admin-bar');"
-        ].join(''),
-        runAt: "document_idle",
-        allFrames: true
-      },
-      function() {
-        wpAdminHide.toggleIcon(true);
-      });
-  },
-
-  restoreBar: function(tabId) {
-    chrome.tabs.executeScript(
-      tabId, {
-        code: [
-          "document.getElementById('wpadminbar').removeAttribute('style');",
-          "document.getElementsByTagName('html')[0].removeAttribute('style');",
-          "document.getElementsByTagName('body')[0].classList.add('admin-bar');"
-        ].join(''),
-        runAt: "document_idle",
-        allFrames: true
-      },
-      function() {
-        wpAdminHide.toggleIcon(false);
-      });
-  },
-
-  /*
-   * This could very well become outdated but I'm rolling with it for now. Function takes a boolean
-   * parameter and switches the icon to on or off while also updating the 'active' variable.
+  /**
+   * Hides the WP admin bar on the current tab
    */
-  toggleIcon: function(state) {
-    if (state) {
-      chrome.browserAction.setIcon({
-        path: {
-          "19": "img/icon19_1.png",
-          "38": "img/icon38_1.png"
-        }
-      });
-    } else {
-      chrome.browserAction.setIcon({
-        path: {
-          "19": "img/icon19_0.png",
-          "38": "img/icon38_0.png"
-        }
-      });
-    }
-  }
+  removeBar: function(tabId) {
+    chrome.scripting.executeScript({
+      target: { tabId: tabId, allFrames: true },
+      func: () => {
+        const bar = document.getElementById('wpadminbar');
+        if (bar) bar.style.display = 'none';
+        document.getElementsByTagName('html')[0].style.setProperty('margin-top', '0px', 'important');
+        document.getElementsByTagName('html')[0].style.setProperty('padding-top', '0px', 'important');
+        document.getElementsByTagName('body')[0].classList.remove('admin-bar');
+      },
+      world: "MAIN"
+    }, () => {
+      wpAdminHide.toggleIcon(true);
+    });
+  },
 
+  /**
+   * Restores the WP admin bar on the current tab
+   */
+  restoreBar: function(tabId) {
+    chrome.scripting.executeScript({
+      target: { tabId: tabId, allFrames: true },
+      func: () => {
+        const bar = document.getElementById('wpadminbar');
+        if (bar) bar.removeAttribute('style');
+        document.getElementsByTagName('html')[0].removeAttribute('style');
+        document.getElementsByTagName('body')[0].classList.add('admin-bar');
+      },
+      world: "MAIN"
+    }, () => {
+      wpAdminHide.toggleIcon(false);
+    });
+  },
+
+  /**
+   * Updates the extension icon to indicate state
+   */
+  toggleIcon: function(isHidden) {
+    chrome.action.setIcon({
+      path: isHidden
+        ? { 19: "/img/icon19_1.png", 38: "/img/icon38_1.png" }
+        : { 19: "/img/icon19_0.png", 38: "/img/icon38_0.png" },
+    });
+  }
 };
 
 /* 
  * Listener for browser action button clickage. Checks the active tab against Chrome storage
  * and toggles the state of the plugin accordingly.
  */
-chrome.browserAction.onClicked.addListener(function(tab) {
+chrome.action.onClicked.addListener((tab) => {
   wpAdminHide.chkD(
     tab.id,
-    function(d) {
-      wpAdminHide.remD(d);
+    function(domain) {
+      wpAdminHide.remD(domain);
       wpAdminHide.restoreBar(tab.id);
     },
-    function(d) {
-      wpAdminHide.addD(d);
+    function(domain) {
+      wpAdminHide.addD(domain);
       wpAdminHide.removeBar(tab.id);
     }
   );
@@ -121,25 +110,26 @@ chrome.browserAction.onClicked.addListener(function(tab) {
  * Going to assume that the hiding was handled on tab load so this is just for keeping up
  * appearances.
  */
-var updateBrowserIcon = function(tab) {
-  var id = tab.tabId || tab.id;
+function updateBrowserIcon(tab) {
+  const tabId = tab.tabId || tab.id;
   wpAdminHide.chkD(
-    id,
-    function() {
-      wpAdminHide.toggleIcon(true);
-    },
-    function() {
-      wpAdminHide.toggleIcon(false);
-    });
-};
+    tabId,
+    function() { wpAdminHide.toggleIcon(true); },
+    function() { wpAdminHide.toggleIcon(false); }
+  );
+}
 
-// Update icon when tab is changed within a single window
+/**
+ * Update icon when tab is changed within a single window
+ */
 chrome.tabs.onActivated.addListener(updateBrowserIcon);
 
-// Update icon when window focus changes
-chrome.windows.onFocusChanged.addListener(function(windowId){
-  chrome.tabs.query({windowId: windowId, active: true}, function(tab){
-    updateBrowserIcon(tab['0']);
+/**
+ * Update icon when window focus changes
+ */
+chrome.windows.onFocusChanged.addListener(function(windowId) {
+  chrome.tabs.query({ windowId: windowId, active: true }, function(tabs) {
+    if (tabs && tabs[0]) updateBrowserIcon(tabs[0]);
   });
 });
 
@@ -147,12 +137,10 @@ chrome.windows.onFocusChanged.addListener(function(windowId){
  * This listener fires each time the user loads a new page. If the domain is recognized
  * then the bar removal script is fired.
  */
-chrome.tabs.onUpdated.addListener(function(tabId, data, tab) {
+chrome.tabs.onUpdated.addListener(function(tabId) {
   wpAdminHide.chkD(
     tabId,
-    function(d) {
-      wpAdminHide.removeBar(tabId);
-    },
-    function(d) {}
+    function() { wpAdminHide.removeBar(tabId); },
+    function() {}
   );
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,31 +1,29 @@
 {
-	"manifest_version": 2,
-
-	"name": "Wordpress Admin Bar Control",
-	"short_name": "WP Admin Bar Hider",
-	"version": "1.1.1",
-	"description": "Hide & show the admin bar with one easy click!",
-	
-	"browser_action": {
-		"default_icon": {
-			"19": "img/icon19_0.png",
-			"38": "img/icon38_0.png"
-		},
-		"default_title": "WP Admin Bar Hider"
-	},
-	
-	"permissions": [
-		"storage",
-		"tabs",
-		"*://*/*"
-	],
-  
-	"background":{
-		"scripts":["lib/brain.js"]
-	},
-
-	"icons": {
-		"128": "img/icon128.png"
-	}
-	
+  "manifest_version": 3,
+  "name": "Wordpress Admin Bar Control",
+  "version": "2.0.0",
+  "description": "Hide & show the admin bar with one easy click!",
+  "icons": {
+    "128": "img/icon128.png"
+  },
+  "action": {
+    "default_icon": {
+      "19": "img/icon19_0.png",
+      "38": "img/icon38_0.png"
+    },
+    "default_title": "WP Admin Bar Hider"
+  },
+  "background": {
+    "service_worker": "lib/brain.js"
+  },
+  "permissions": [
+    "storage",
+    "tabs",
+    "scripting",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "short_name": "WP Admin Bar Hider"
 }


### PR DESCRIPTION
### Description

This PR upgrades the this extension from Manifest V2 to Manifest V3, ensuring continued compatibility with Chrome and compliance with the latest extension standards. This is a major release (`2.0.0`) as it introduces a technical overhaul to restore functionality in new Chrome versions.

---

### Why this change?

**As of Chrome version 138, Google has officially disabled access to this extension (and all Manifest V2 extensions), even if they were previously installed. Users now see:**
> _"This extension is no longer available because it doesn't follow best practices for Chrome extensions."_

**This update is required to restore functionality and comply with Chrome’s latest extension requirements.**

---

### Key Changes

- **Upgraded to Manifest V3**
  - Updated `manifest.json` to use `"manifest_version": 3`
  - Replaced background scripts with a service worker (`background.service_worker`)
  - Migrated from `browser_action` to `action`
  - Updated permissions and host permissions for V3 compliance

- **Codebase Modernization**
  - Replaced deprecated APIs (`chrome.tabs.executeScript` → `chrome.scripting.executeScript`, etc.)
  - Updated all icon paths to use absolute paths for compatibility with service workers
  - Commented out all console logging for a cleaner production build
  - Cleaned up and commented JavaScript for readability and maintainability

- **Version Bump**
  - Bumped version to `2.0.0` to reflect the major technical upgrade and restoration of extension functionality for Chrome 138+ users
---

### Testing

- Extension loads and runs as Manifest V3 in Chrome (v138+)
- Service worker is active (visible in `chrome://extensions`)
- All original features (admin bar toggle, icon state, etc.) work as expected
- No errors or warnings in the service worker console

---

### Notes

- This release is not backward-compatible with Manifest V2
- Users must be on a version of Chrome that supports Manifest V3
- The extension is now future-proof and eligible for re-publishing on the Chrome Web Store